### PR TITLE
angler: fix first audio track

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -54,6 +54,8 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_CMDLINE := androidboot.hardware=angler androidboot.console=ttyHSL0 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 boot_cpus=0-7 androidboot.selinux=permissive
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
 
+# Audio
+AUDIO_FEATURE_ENABLED_SPKR_PROTECTION := true
 BOARD_USES_ALSA_AUDIO := true
 # Needed for VoLTE
 AUDIO_FEATURE_ENABLED_MULTI_VOICE_SESSIONS := true

--- a/device.mk
+++ b/device.mk
@@ -346,6 +346,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.audio.flinger_standbytime_ms=300
 
+# Enable speaker calibration
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.speaker.prot.enable=true
+
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.ssr.restart_level="ALL_ENABLE"
 

--- a/init.angler.rc
+++ b/init.angler.rc
@@ -147,6 +147,9 @@ on post-fs-data
 
     # Create /data/time folder for time-services
     mkdir /data/time/ 0700 system system
+
+    # Audio
+    mkdir /data/misc/audio 0770 audio audio
     mkdir /data/audio/ 0770 media audio
 
     # Create folder for perf daemon


### PR DESCRIPTION
It seems that the first time an audio track was played was when the
audio clibration data is sent down to the hw. However it wasn't being
properly applied or we missed it and that first track will always sound
awful.

The speaker protection extension fixes this by pre-loading the
calibration data before the first track is played.

Ticket: OSS CYAN-7486
Change-Id: Ibb1ace9dfbf2c1dec4844d1eedd8843889415792
Signed-off-by: Roman Birg roman@cyngn.com
